### PR TITLE
Clear exit timeouts on unmount

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -116,6 +116,10 @@ const Popover = createClass({
     else if (didClose) this.exit()
   },
   componentWillUnmount () {
+    /* If the Popover is unmounted while animating,
+    clear the animation so no setState occured */
+    this.animateExitStop()
+    
     /* If the Popover was never opened then then tracking
     initialization never took place and so calling untrack
     would be an error. Also see issue 55. */


### PR DESCRIPTION
It's to prevent the setState call on an unmounted Popover